### PR TITLE
MX5: Add Flashing script to MX5 images

### DIFF
--- a/recipes-images/images/console-hostmobility-image.bb
+++ b/recipes-images/images/console-hostmobility-image.bb
@@ -35,6 +35,7 @@ IMAGE_INSTALL_append_mx6 += " \
     rng-tools \
     uart-test \
     dfu-util \
+    u-boot-hostmobility-flash-mx5 \
 "
 
 IMAGE_DEV_MANAGER   = "udev"


### PR DESCRIPTION
Add a recipe(from meta-hostmobility-bsp) for building of a script to be
put on a USB stick to flash an MX5 together with an image.