### PR TITLE
Hostapd: set service to default disable

### DIFF
--- a/recipes-connectivity/hostapd/hostapd_%.bbappend
+++ b/recipes-connectivity/hostapd/hostapd_%.bbappend
@@ -4,7 +4,8 @@ SRC_URI:append = " \
     file://hostapd_custom.conf \
 "
 SYSTEMD_SERVICE:${PN} = "hostapd.service"
-SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+# Set this to enable if you want your bsp image to start the ap mode direct from first startup.
+SYSTEMD_AUTO_ENABLE:${PN} = "disable"
 
 do_install:append() {
     install -m 0644 ${WORKDIR}/hostapd_custom.conf ${D}${sysconfdir}/hostapd_custom.conf


### PR DESCRIPTION
The hostapd package is included in the system and for  some users that will run other wlan modes cant do it if the system is already started hostapd. This hostapd bbappend is an example of how to add a AP mode network. You can try it out
with systemctl start hostapd. this example will add a network ssid HostMobility-Test-Network.