### PR TITLE
console-hostmobility-image: remove u-boot-hostmobility-flash-mx5

### DIFF
--- a/recipes-images/images/console-hostmobility-image.bb
+++ b/recipes-images/images/console-hostmobility-image.bb
@@ -39,9 +39,6 @@ IMAGE_INSTALL:append:mxv-base = " \
     dfu-util \
 "
 
-IMAGE_INSTALL:append:mx5-pt = " \
-    u-boot-hostmobility-flash-mx5 \
-"
 
 IMAGE_DEV_MANAGER   = "udev"
 IMAGE_INIT_MANAGER  = "systemd"


### PR DESCRIPTION
this is now active in bsp layer with name flash-script