### PR TITLE
Let Host Insight Helper execute software upgrades

### DIFF
--- a/recipes-support/host-insight-helper/host-insight-helper/host-insight-helper.sh
+++ b/recipes-support/host-insight-helper/host-insight-helper/host-insight-helper.sh
@@ -24,8 +24,15 @@ assign_uid_and_fallback_domain()
 {
   # Get the serial number of the device.
   if [ "$(cat /etc/platform-system-type)" = "c61" ]; then
-    # Sleep until we know that pic_upgrade is complete
-    sleep 30
+    if command -v pgrep >/dev/null 2>&1; then
+      while pgrep -f "/opt/hm/pic_upgrade.sh" >/dev/null 2>&1; do
+        # pic_upgrade is still running
+        sleep 1
+      done
+    else
+      # Sleep until we suspect that pic_upgrade is complete
+      sleep 30
+    fi
     echo "uid = \"$(cat /opt/hm/pic_attributes/ctrl_serial_nr)\"" > "$ID_PATH"
   else
     echo "uid = \"$(cat /proc/device-tree/chosen/serial-number)\"" > "$ID_PATH"


### PR DESCRIPTION
The client has difficulties upgrading itself so we can use the helper to do it instead.

Use the file `/tmp/host-insight/client_upgrade` to communicate both that an upgrade is available and the major version requested.