### PR TITLE
Generic conf: Add meta-filesystems

### DIFF
--- a/conf/generic/bblayers.conf.sample
+++ b/conf/generic/bblayers.conf.sample
@@ -13,6 +13,7 @@ BBLAYERS = " \
   ${BSPDIR}/sources/meta-openembedded/meta-networking \
   ${BSPDIR}/sources/meta-openembedded/meta-python \
   ${BSPDIR}/sources/meta-openembedded/meta-gnome \
+  ${BSPDIR}/sources/meta-openembedded/meta-filesystems \
   \
   ${BSPDIR}/sources/meta-freescale \
   ${BSPDIR}/sources/meta-freescale-distro \


### PR DESCRIPTION
This adds recipies such as fuse. It is also a required dependency for the virtualization-layer.