### PR TITLE
conf: Enable distro features virtualization and kvm

### DIFF
--- a/conf/generic/local.conf.sample
+++ b/conf/generic/local.conf.sample
@@ -25,6 +25,8 @@ ACCEPT_FSL_EULA = "1"
 INHERIT += "rm_work"
 
 DISTRO_FEATURES:append = " systemd"
+DISTRO_FEATURES:append = " virtualization"
+DISTRO_FEATURES:append = " kvm"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""

--- a/conf/hmx/local.conf.sample
+++ b/conf/hmx/local.conf.sample
@@ -25,6 +25,8 @@ ACCEPT_FSL_EULA = "1"
 INHERIT += "rm_work"
 
 DISTRO_FEATURES:append = " systemd"
+DISTRO_FEATURES:append = " virtualization"
+DISTRO_FEATURES:append = " kvm"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 DISTRO_FEATURES_BACKFILL_CONSIDERED = "sysvinit"
 VIRTUAL-RUNTIME_initscripts = ""


### PR DESCRIPTION
This should remove the following warning:

```
WARNING: You have included the meta-virtualization layer, but 'virtualization' has not been enabled in your DISTRO_FEATURES. Some bbappend files may not take effect. See the meta-virtualization README for details on enabling virtualization support.
```