### PR TITLE
Update resizefs.sh:fix error print when no emmc found

### DIFF
--- a/recipes-core/fs-init/files/resizefs.sh
+++ b/recipes-core/fs-init/files/resizefs.sh
@@ -48,6 +48,6 @@ if grep "/$DISK" /proc/cmdline; then
 
     logger "resizing ${DISK}p$PART finished, new size is $(df --output=avail -h )"
 else
-    echo "$(cat/proc/cmdline) is not target eMMC(${DISK}p$PART). Skip resize eMMC and exit 1"
+    echo "$(cat /proc/cmdline) is not target eMMC(${DISK}p$PART). Skip resize eMMC and exit 1"
     exit 1
 fi


### PR DESCRIPTION
missing a space on cat. still i think uboot need to be updated on some platforms to support this.