### PR TITLE
Add deploy_mobility directory for image outputs

### DIFF
--- a/classes/deploy_mobility.bbclass
+++ b/classes/deploy_mobility.bbclass
@@ -15,7 +15,7 @@
 # - Custom deployment directories can be modified by setting
 #   `DEPLOY_DIR_EXTRA_IMAGE` in `local.conf`
 
-DEPLOY_DIR_EXTRA_IMAGE = "${TOPDIR}/deploy-mobility/images"
+DEPLOY_DIR_EXTRA_IMAGE ?= "${TOPDIR}/deploy-mobility/images"
 
 do_deploy_mobility() {
     mkdir -p ${DEPLOY_DIR_EXTRA_IMAGE}

--- a/classes/deploy_mobility.bbclass
+++ b/classes/deploy_mobility.bbclass
@@ -1,0 +1,25 @@
+# Copyright SETEK Systems AB
+#
+# SPDX-License-Identifier: MIT
+#
+# deploy-mobility.bbclass - Reference image deployment setup
+#
+# This class provides an additional deployment location by creating
+# symbolic links to the default BitBake deploy directory.
+#
+# This will make the build more compatible with our "bygg" script from mobility-platform.
+#
+# Usage:
+# - Add `INHERIT += "deploy-mobility"` to `local.conf`
+#
+# - Custom deployment directories can be modified by setting
+#   `DEPLOY_DIR_EXTRA_IMAGE` in `local.conf`
+
+DEPLOY_DIR_EXTRA_IMAGE = "${TOPDIR}/deploy-mobility/images"
+
+do_deploy_mobility() {
+    mkdir -p ${DEPLOY_DIR_EXTRA_IMAGE}
+    ln -snf ${DEPLOY_DIR_IMAGE} ${DEPLOY_DIR_EXTRA_IMAGE}/
+}
+
+addtask do_deploy_mobility after do_deploy before do_build

--- a/conf/templates/generic/local.conf.sample
+++ b/conf/templates/generic/local.conf.sample
@@ -22,7 +22,7 @@ PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
 CONF_VERSION = "2"
 ACCEPT_FSL_EULA = "1"
 
-INHERIT += "rm_work"
+INHERIT += "rm_work deploy_mobility"
 
 DISTRO_FEATURES:append = " usrmerge"
 DISTRO_FEATURES:append = " systemd"

--- a/conf/templates/hmm/local.conf.sample
+++ b/conf/templates/hmm/local.conf.sample
@@ -21,7 +21,7 @@ PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
 
 CONF_VERSION = "2"
 
-INHERIT += "rm_work"
+INHERIT += "rm_work deploy_mobility"
 
 DISTRO_FEATURES:append = " usrmerge"
 DISTRO_FEATURES:append = " systemd"

--- a/conf/templates/hmx/local.conf.sample
+++ b/conf/templates/hmx/local.conf.sample
@@ -22,7 +22,7 @@ PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
 CONF_VERSION = "2"
 ACCEPT_FSL_EULA = "1"
 
-INHERIT += "rm_work"
+INHERIT += "rm_work deploy_mobility"
 
 DISTRO_FEATURES:append = " usrmerge"
 DISTRO_FEATURES:append = " systemd"


### PR DESCRIPTION
This makes our refrene builds using script/bygg the same where to look for images and firmware files. This only include a symlink to where the files are located. for example most of the builds are in tmp/deploy/images and for hmm it is under deploy-ti.