### PR TITLE
starve-frontend: Skip recipe gracefully when GitLab token unavailable

### DIFF
--- a/recipes-robotframework/starve-setup/starve-frontend.bb
+++ b/recipes-robotframework/starve-setup/starve-frontend.bb
@@ -11,7 +11,7 @@ python () {
     import os
     access_token = os.getenv("GITLAB_ACCESS_TOKEN", "")
     if not access_token:
-        bb.fatal("GITLAB_ACCESS_TOKEN is not set in the environment. Fetching from GitLab will fail.")
+        raise bb.parse.SkipRecipe("GITLAB_ACCESS_TOKEN not available in the environment")
     d.setVar("GITLAB_ACCESS_TOKEN", access_token)
 }
 

--- a/recipes-robotframework/starve-setup/starve-frontend.bb
+++ b/recipes-robotframework/starve-setup/starve-frontend.bb
@@ -15,12 +15,6 @@ python () {
     d.setVar("GITLAB_ACCESS_TOKEN", access_token)
 }
 
-SRC_URI = " \
-    https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/jobs/${GITLAB_BUILD_JOB_ID}/artifacts/starve_frontend-${PV}.tar.gz;name=starve_frontend;downloadfilename=starve_frontend-${PV}.tar.gz \
-"
-SRC_URI[starve_frontend.md5sum] = "e3cfcedf9e1df6a9adcc90b397250b5c"
-SRC_URI[starve_frontend.sha256sum] = "4850bf7a2d72bcf8dc069e60afc487dcb51808232d6a4852f65158793154990b"
-
 do_fetch() {
     TOKEN="${GITLAB_ACCESS_TOKEN}"
     URL="https://gitlab.com/api/v4/projects/${GITLAB_PROJECT_ID}/jobs/${GITLAB_BUILD_JOB_ID}/artifacts/starve_frontend-${PV}.tar.gz"


### PR DESCRIPTION
Use bb.parse.SkipRecipe() to skip the recipe when GITLAB_ACCESS_TOKEN is not set, preventing build failures for images that don't need this component while providing clear error messages for images that do.
