### PR TITLE
HMX: scarthgap: add support for imx8mp var dart rev 2.0

### DIFF
--- a/conf/templates/hmx/bblayers.conf.sample
+++ b/conf/templates/hmx/bblayers.conf.sample
@@ -15,30 +15,25 @@ BBLAYERS = " \
   ${BSPDIR}/sources/meta-openembedded/meta-gnome \
   ${BSPDIR}/sources/meta-openembedded/meta-filesystems \
   \
-  ${BSPDIR}/sources/meta-freescale \
-  ${BSPDIR}/sources/meta-freescale-3rdparty \
-  ${BSPDIR}/sources/meta-freescale-distro \
-  ${BSPDIR}/sources/meta-freescale-ml \
-  \
   ${BSPDIR}/sources/meta-qt5 \
   ${BSPDIR}/sources/meta-swupdate \
   ${BSPDIR}/sources/meta-virtualization \
   \
+  ${BSPDIR}/sources/meta-freescale \
+  ${BSPDIR}/sources/meta-freescale-3rdparty \
+  ${BSPDIR}/sources/meta-freescale-distro \
+  \
+  ${BSPDIR}/sources/meta-imx/meta-imx-bsp \
+  ${BSPDIR}/sources/meta-nxp-connectivity/meta-nxp-openthread \
+  \
+  ${BSPDIR}/sources/meta-variscite-bsp-common \
+  ${BSPDIR}/sources/meta-variscite-bsp-imx \
+  ${BSPDIR}/sources/meta-variscite-sdk-common \
   ${BSPDIR}/sources/meta-variscite-hab \
   \
+  ${BSPDIR}/sources/meta-arm/meta-arm \
+  ${BSPDIR}/sources/meta-arm/meta-arm-toolchain \
   \
   ${BSPDIR}/sources/meta-hostmobility-bsp \
   ${BSPDIR}/sources/meta-mobility-poky-distro \
 "
-# Below is scartghap new name or new layer included. Some of these layers could be removed and not needed if we only use the variscite kernel.
-
-BBLAYERS += "${@'${BSPDIR}/sources/meta-imx/meta-imx-sdk' if os.path.exists('${BSPDIR}/sources/meta-imx/meta-imx-sdk') else ' '}"
-BBLAYERS += "${@'${BSPDIR}/sources/meta-imx/meta-imx-bsp' if os.path.exists('${BSPDIR}/sources/meta-imx/meta-imx-bsp') else ' '}"
-
-BBLAYERS += "${@'${BSPDIR}/sources/meta-variscite-bsp-imx' if os.path.exists('${BSPDIR}/sources/meta-variscite-bsp-imx') else '${BSPDIR}/sources/meta-variscite-bsp'}"
-BBLAYERS += "${@'${BSPDIR}/sources/meta-variscite-bsp-common' if os.path.exists('${BSPDIR}/sources/meta-variscite-bsp-common') else ' '}"
-BBLAYERS += "${@'${BSPDIR}/sources/meta-variscite-sdk-imx' if os.path.exists('${BSPDIR}/sources/meta-variscite-sdk-imx') else ' '}"
-BBLAYERS += "${@'${BSPDIR}/sources/meta-variscite-sdk-common' if os.path.exists('${BSPDIR}/sources/meta-variscite-sdk-common') else ' '}"
-
-BBLAYERS += "${@'${BSPDIR}/sources/meta-arm/meta-arm' if os.path.exists('${BSPDIR}/sources/meta-arm/meta-arm') else ' '}"
-BBLAYERS += "${@'${BSPDIR}/sources/meta-arm/meta-arm-toolchain' if os.path.exists('${BSPDIR}/sources/meta-arm/meta-arm-toolchain') else ' '}"

--- a/conf/templates/hmx/local.conf.sample
+++ b/conf/templates/hmx/local.conf.sample
@@ -40,4 +40,3 @@ ERROR_QA:remove = "version-going-backwards"
 
 DL_DIR ?= "${BSPDIR}/downloads/"
 
-PREFERRED_VERSION_libgpiod = "1.6.%"

--- a/recipes-core/systemd-conf/files/usb1.network
+++ b/recipes-core/systemd-conf/files/usb1.network
@@ -5,8 +5,7 @@ KernelCommandLine=!nfsroot
 KernelCommandLine=!ip
 
 [Network]
-Address=192.168.250.1
-
+Address=192.168.250.1/24
 DHCPServer=true
 
 [DHCPServer]


### PR DESCRIPTION
**To be merged together with.**

_meta-hostmobility-bsp:_
- [HMX: scarthgap: add support for imx8mp var dart rev 2.0](https://github.com/hostmobility/meta-hostmobility-bsp/pull/128)

_mobility-poky-platform_
- [schartgap-next: update to scarthgap 6.6.52-2.2.0 release](https://github.com/hostmobility/mobility-poky-platform/pull/73)