### PR TITLE
HMX: Add machine learning enabled image

### DIFF
--- a/conf/templates/hmx/bblayers.conf.sample
+++ b/conf/templates/hmx/bblayers.conf.sample
@@ -25,11 +25,14 @@ BBLAYERS = " \
   \
   ${BSPDIR}/sources/meta-imx/meta-imx-bsp \
   ${BSPDIR}/sources/meta-nxp-connectivity/meta-nxp-openthread \
+  ${BSPDIR}/sources/meta-imx/meta-imx-ml \
+  ${BSPDIR}/sources/meta-imx/meta-imx-sdk \
   \
   ${BSPDIR}/sources/meta-variscite-bsp-common \
   ${BSPDIR}/sources/meta-variscite-bsp-imx \
-  ${BSPDIR}/sources/meta-variscite-sdk-common \
   ${BSPDIR}/sources/meta-variscite-hab \
+  ${BSPDIR}/sources/meta-variscite-sdk-common \
+  ${BSPDIR}/sources/meta-variscite-sdk-imx \
   \
   ${BSPDIR}/sources/meta-arm/meta-arm \
   ${BSPDIR}/sources/meta-arm/meta-arm-toolchain \

--- a/conf/templates/hmx/conf-notes.txt
+++ b/conf/templates/hmx/conf-notes.txt
@@ -1,5 +1,7 @@
 Host Mobility targets are:
-    1. console-hostmobility-image *console only*
+    1. console-hostmobility-image 'console only'
     2. host-insight-image 'console only with host-insight-client support'
+    3. console-image-ml 'console only with machine learning support'
 Machine compatible
     imx8mp-var-dart-hmx1
+    

--- a/recipes-images/images/console-image-ml.bb
+++ b/recipes-images/images/console-image-ml.bb
@@ -1,0 +1,11 @@
+DESCRIPTION = "A console-only image with machine learning support"
+
+LICENSE = "MIT"
+
+require console-hostmobility-image.bb
+
+IMAGE_INSTALL:append = " \
+    packagegroup-variscite-imx-ml \
+"
+
+export IMAGE_BASENAME = "console-image-ml"

--- a/recipes-libraries/onnxruntime/files/0001-move-Variscites-Eigen-patch-to-onnxruntime-1.16.1.patch
+++ b/recipes-libraries/onnxruntime/files/0001-move-Variscites-Eigen-patch-to-onnxruntime-1.16.1.patch
@@ -1,0 +1,43 @@
+
+From 3a0c5834322de5f776f7013ec2e9c64d3cdba320 Mon Sep 17 00:00:00 2001
+From: Host Mobility Support <support@hostmobility.com>
+Date: Wed, 29 Oct 2025 14:48:14 +0000
+Subject: [PATCH] eigen: move Variscites Eigen patch to onnxruntime 1.16.1
+
+This patch applies changes from Variscites patch:
+0001-eigen-replace-Eigen-zip-download-with-Git-clone-to-a.patch  
+But for onnxruntime 1.16.1
+
+Signed-off-by: Andreas Ternstedt <a.ternstedt@setek.se>
+
+---
+ cmake/deps.txt             | 1 -
+ cmake/external/eigen.cmake | 4 ++--
+ 2 files changed, 2 insertions(+), 3 deletions(-)
+
+diff --git a/cmake/deps.txt b/cmake/deps.txt
+index 631c9cf2f..01251a4bb 100644
+--- a/cmake/deps.txt
++++ b/cmake/deps.txt
+@@ -42,4 +42,3 @@ safeint;https://github.com/dcleblanc/SafeInt/archive/ff15c6ada150a5018c5ef217240
+ tensorboard;https://github.com/tensorflow/tensorboard/archive/373eb09e4c5d2b3cc2493f0949dc4be6b6a45e81.zip;67b833913605a4f3f499894ab11528a702c2b381
+ cutlass;https://github.com/NVIDIA/cutlass/archive/refs/tags/v3.0.0.zip;0f95b3c1fc1bd1175c4a90b2c9e39074d1bccefd
+ extensions;https://github.com/microsoft/onnxruntime-extensions/archive/94142d8391c9791ec71c38336436319a2d4ac7a0.zip;4365ac5140338b4cb75a39944a4be276e3829b3c
+-eigen;https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-3.4.0.zip;ef24286b7ece8737c99fa831b02941843546c081
+diff --git a/cmake/external/eigen.cmake b/cmake/external/eigen.cmake
+index c0f7ddc50..58c74ab17 100644
+--- a/cmake/external/eigen.cmake
++++ b/cmake/external/eigen.cmake
+@@ -14,8 +14,8 @@ else ()
+     else()
+         FetchContent_Declare(
+             eigen
+-            URL ${DEP_URL_eigen}
+-            URL_HASH SHA1=${DEP_SHA1_eigen}
++            GIT_REPOSITORY https://gitlab.com/libeigen/eigen.git
++            GIT_TAG        e7248b26a1ed53fa030c5c459f7ea095dfd276ac
+         )
+     endif()
+     FetchContent_Populate(eigen)
+-- 
+2.34.1

--- a/recipes-libraries/onnxruntime/files/0002-mlas-remove-fp16-cortex-a53.patch
+++ b/recipes-libraries/onnxruntime/files/0002-mlas-remove-fp16-cortex-a53.patch
@@ -1,0 +1,56 @@
+From fa66089bd5401193b166fc2cb567626e62dafd7a Mon Sep 17 00:00:00 2001
+From: Andreas Ternstedt <a.ternstedt@setek.se>
+Date: Tue, 28 Oct 2025 14:43:34 +0000
+Subject: [PATCH] mlas: Remove ARMv8.2+ optimizations for Cortex-A53
+ compatibility
+
+Remove dependancies of ARMv8.2-a instruction set.
+These are optional runtime optimizations not supported by Cortex-A53 (ARMv8.0).
+
+Signed-off-by: Andreas Ternstedt <a.ternstedt@setek.se>
+
+---
+ cmake/onnxruntime_mlas.cmake     | 14 --------------
+ onnxruntime/core/mlas/inc/mlas.h |  2 +-
+ 2 files changed, 1 insertion(+), 15 deletions(-)
+
+diff --git a/cmake/onnxruntime_mlas.cmake b/cmake/onnxruntime_mlas.cmake
+index e0ccc504d..79293a9f0 100644
+--- a/cmake/onnxruntime_mlas.cmake
++++ b/cmake/onnxruntime_mlas.cmake
+@@ -335,20 +335,6 @@ else()
+           ${MLAS_SRC_DIR}/qgemm_kernel_udot.cpp
+           ${MLAS_SRC_DIR}/qgemm_kernel_sdot.cpp
+         )
+-        if (NOT APPLE)
+-          set(mlas_platform_srcs
+-            ${mlas_platform_srcs}
+-            ${MLAS_SRC_DIR}/aarch64/HalfGemmKernelNeon.S
+-            ${MLAS_SRC_DIR}/activate_fp16.cpp
+-            ${MLAS_SRC_DIR}/dwconv.cpp
+-            ${MLAS_SRC_DIR}/halfgemm_kernel_neon.cpp
+-            ${MLAS_SRC_DIR}/pooling_fp16.cpp
+-          )
+-          set_source_files_properties(${MLAS_SRC_DIR}/aarch64/HalfGemmKernelNeon.S PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
+-          set_source_files_properties(${MLAS_SRC_DIR}/activate_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
+-          set_source_files_properties(${MLAS_SRC_DIR}/dwconv.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
+-          set_source_files_properties(${MLAS_SRC_DIR}/pooling_fp16.cpp PROPERTIES COMPILE_FLAGS " -march=armv8.2-a+fp16 ")
+-        endif()
+ 
+         if(ONNXRUNTIME_MLAS_MULTI_ARCH)
+             onnxruntime_add_static_library(onnxruntime_mlas_arm64 ${mlas_platform_srcs})
+diff --git a/onnxruntime/core/mlas/inc/mlas.h b/onnxruntime/core/mlas/inc/mlas.h
+index fd6b3df93..8a0dd8d19 100644
+--- a/onnxruntime/core/mlas/inc/mlas.h
++++ b/onnxruntime/core/mlas/inc/mlas.h
+@@ -85,7 +85,7 @@ Abstract:
+ // When building an universial binary for APPLE, this flag would
+ // cause trouble for x64 target.
+ 
+-#define MLAS_F16VEC_INTRINSICS_SUPPORTED
++//#define MLAS_F16VEC_INTRINSICS_SUPPORTED
+ 
+ #endif // 
+ #endif // ARM64
+-- 
+2.34.1

--- a/recipes-libraries/onnxruntime/onnxruntime_%.bbappend
+++ b/recipes-libraries/onnxruntime/onnxruntime_%.bbappend
@@ -1,0 +1,18 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Remove Variscite's eigen patch
+SRC_URI:remove = " file://0001-eigen-replace-Eigen-zip-download-with-Git-clone-to-a.patch"
+
+SRC_URI:append = " \
+    file://0001-fix-Variscites-Eigen-patch-to-onnxruntime-1.16.1.patch \
+    file://0002-mlas-remove-fp16-cortex-a53.patch \
+"
+
+TARGET_CXXFLAGS:append = " -Wno-error=range-loop-construct"
+
+# Use ONNX Runtime 1.16.1 from older branch
+SRCBRANCH = "lf-6.1.55_2.2.0"
+SRCREV = "1582e774d7c120a5dfbdbf6e11c8788e710ab93f"
+
+# Fix version to match actual code
+PV = "1.16.1"


### PR DESCRIPTION
New image type: console-image-ml

Image have dependency of packagegroup-variscite-imx-ml and packagegroup-imx-ml (NXP). 

At Scarthgap (6.6.52-2.2.0) NXP's meta-imx-ml forks ONNX runtime at version 1.17.1. 

ONNX Runtime 1.17.1 introduced mandatory ARMv8.2+ dependencies (dotprod, fp16, i8mm, bf16) that are not supported by Cortex-A53 (ARMv8.0). While the code compiles with generic armv8a tuning, it crashes at runtime with "Illegal instruction" when trying to execute ARMv8.2 instructions. Therefore the ONNX runtime is downgraded to version 1.16.1, as it is possible to patch this version to only use ARMv8.0 instructions.