### PR TITLE
hmm: bblayers: Include meta-freescale layer

### DIFF
--- a/conf/templates/hmm/bblayers.conf.sample
+++ b/conf/templates/hmm/bblayers.conf.sample
@@ -15,6 +15,8 @@ BBLAYERS = " \
   ${BSPDIR}/sources/meta-openembedded/meta-gnome \
   ${BSPDIR}/sources/meta-openembedded/meta-filesystems \
   \
+  ${BSPDIR}/sources/meta-freescale \
+  \
   ${BSPDIR}/sources/meta-qt5 \
   ${BSPDIR}/sources/meta-swupdate \
   ${BSPDIR}/sources/meta-virtualization \


### PR DESCRIPTION
Add three meta-freescale layers that seem to be required by more recent meta-toradex-ti revisions.

To be merged together with:
- https://github.com/hostmobility/meta-hostmobility-bsp/pull/133
- https://github.com/hostmobility/mobility-poky-platform/pull/76