### PR TITLE
hmm, hmx: conf: templates: DISTRO_FEATURES:remove = " sysvinit"

### DIFF
--- a/conf/templates/hmm/local.conf.sample
+++ b/conf/templates/hmm/local.conf.sample
@@ -27,6 +27,7 @@ DISTRO_FEATURES:append = " usrmerge"
 DISTRO_FEATURES:append = " systemd"
 DISTRO_FEATURES:append = " virtualization"
 #DISTRO_FEATURES:append = " kvm"
+DISTRO_FEATURES:remove = " sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
 LICENSE_FLAGS_ACCEPTED = "commercial"

--- a/conf/templates/hmx/local.conf.sample
+++ b/conf/templates/hmx/local.conf.sample
@@ -28,6 +28,7 @@ DISTRO_FEATURES:append = " usrmerge"
 DISTRO_FEATURES:append = " systemd"
 DISTRO_FEATURES:append = " virtualization"
 #DISTRO_FEATURES:append = " kvm"
+DISTRO_FEATURES:remove = " sysvinit"
 VIRTUAL-RUNTIME_init_manager = "systemd"
 
 LICENSE_FLAGS_ACCEPTED = "commercial"


### PR DESCRIPTION
All our platforms support only systemd as the init system, but unless sysvinit is explicitly removed you get many dmesg warnings that start with "systemd-sysv-generator[85]: SysV service '/etc/init.d/sshd' lacks a native systemd unit file".