### PR TITLE
hmm, hmx, generic, mxv: conf: templates: Enable cve-check

### DIFF
--- a/conf/templates/generic/local.conf.sample
+++ b/conf/templates/generic/local.conf.sample
@@ -23,6 +23,8 @@ CONF_VERSION = "2"
 ACCEPT_FSL_EULA = "1"
 
 INHERIT += "rm_work deploy_mobility"
+INHERIT += "cve-check"
+include conf/distro/include/cve-extra-exclusions.inc
 
 DISTRO_FEATURES:append = " usrmerge"
 DISTRO_FEATURES:append = " systemd"

--- a/conf/templates/hmm/local.conf.sample
+++ b/conf/templates/hmm/local.conf.sample
@@ -22,6 +22,8 @@ PACKAGECONFIG:append:pn-nativesdk-qemu = " sdl"
 CONF_VERSION = "2"
 
 INHERIT += "rm_work deploy_mobility"
+INHERIT += "cve-check"
+include conf/distro/include/cve-extra-exclusions.inc
 
 DISTRO_FEATURES:append = " usrmerge"
 DISTRO_FEATURES:append = " systemd"

--- a/conf/templates/hmx/local.conf.sample
+++ b/conf/templates/hmx/local.conf.sample
@@ -23,6 +23,8 @@ CONF_VERSION = "2"
 ACCEPT_FSL_EULA = "1"
 
 INHERIT += "rm_work deploy_mobility"
+INHERIT += "cve-check"
+include conf/distro/include/cve-extra-exclusions.inc
 
 DISTRO_FEATURES:append = " usrmerge"
 DISTRO_FEATURES:append = " systemd"

--- a/conf/templates/mxv/local.conf.sample
+++ b/conf/templates/mxv/local.conf.sample
@@ -23,6 +23,8 @@ CONF_VERSION = "2"
 ACCEPT_FSL_EULA = "1"
 
 INHERIT += "rm_work deploy_mobility"
+INHERIT += "cve-check"
+include conf/distro/include/cve-extra-exclusions.inc
 
 DISTRO_FEATURES:append = " usrmerge"
 DISTRO_FEATURES:append = " systemd"


### PR DESCRIPTION
Add INHERIT += "cve-check" to local.conf.sample templates so CVE reporting can be enabled via the build script without requiring manual configuration.