### PR TITLE
HMX, MXV, generic: conf: Remove preferred version of libgpiod

### DIFF
--- a/conf/templates/generic/local.conf.sample
+++ b/conf/templates/generic/local.conf.sample
@@ -39,5 +39,3 @@ DISTRO_FEED_ARCHS += "all ${PACKAGE_EXTRA_ARCHS} ${MACHINE_ARCH}"
 ERROR_QA:remove = "version-going-backwards"
 
 DL_DIR ?= "${BSPDIR}/downloads/"
-
-PREFERRED_VERSION_libgpiod = "1.6.%"

--- a/conf/templates/hmm/local.conf.sample
+++ b/conf/templates/hmm/local.conf.sample
@@ -39,5 +39,3 @@ DISTRO_FEED_ARCHS += "all ${PACKAGE_EXTRA_ARCHS} ${MACHINE_ARCH}"
 ERROR_QA:remove = "version-going-backwards"
 
 DL_DIR ?= "${BSPDIR}/downloads/"
-
-PREFERRED_VERSION_libgpiod = "1.6.%"

--- a/conf/templates/mxv/local.conf.sample
+++ b/conf/templates/mxv/local.conf.sample
@@ -39,5 +39,3 @@ DISTRO_FEED_ARCHS += "all ${PACKAGE_EXTRA_ARCHS} ${MACHINE_ARCH}"
 ERROR_QA:remove = "version-going-backwards"
 
 DL_DIR ?= "${BSPDIR}/downloads/"
-
-PREFERRED_VERSION_libgpiod = "1.6.%"


### PR DESCRIPTION
This removes the rule that holds back libgpiod on Scarthgap for the remaining machines.