### PR TITLE
HMX: add OpenSSL 3.5 bbappend for NXP BSP builds

### DIFF
--- a/conf/templates/hmx/local.conf.sample
+++ b/conf/templates/hmx/local.conf.sample
@@ -40,4 +40,5 @@ DISTRO_FEED_ARCHS += "all ${PACKAGE_EXTRA_ARCHS} ${MACHINE_ARCH}"
 ERROR_QA:remove = "version-going-backwards"
 
 DL_DIR ?= "${BSPDIR}/downloads/"
-
+# meta-imx scarthgap append targets OpenSSL 3.2, but this build uses OpenSSL 3.5.
+BBMASK += ".*/meta-imx-bsp/recipes-connectivity/openssl/openssl_3\.2\.%\.bbappend"

--- a/recipes-connectivity/openssl/openssl/openssl-3.0-add-Kernel-TLS-configuration.patch
+++ b/recipes-connectivity/openssl/openssl/openssl-3.0-add-Kernel-TLS-configuration.patch
@@ -1,0 +1,34 @@
+From 24254454e5f5fc503b5e4cc1fa8c6d9b1a3ae9ba Mon Sep 17 00:00:00 2001
+From: Gaurav Jain <gaurav.jain@nxp.com>
+Date: Wed, 19 Jan 2022 15:45:29 +0530
+Subject: [PATCH] openssl 3.0: add Kernel TLS configuration
+
+Upstream-Status: Inappropriate [i.MX, Layerscape specific]
+Signed-off-by: Gaurav Jain <gaurav.jain@nxp.com>
+---
+ apps/openssl.cnf | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/apps/openssl.cnf b/apps/openssl.cnf
+index 03330e0120..ec18df388e 100644
+--- a/apps/openssl.cnf
++++ b/apps/openssl.cnf
+@@ -30,6 +30,15 @@ oid_section = new_oids
+ # (Alternatively, use a configuration file that has only
+ # X.509v3 extensions in its main [= default] section.)
+ 
++[ openssl_init ]
++ssl_conf = ssl_configuration
++
++[ ssl_configuration ]
++ktls = ktls_conf
++
++[ ktls_conf ]
++Options = KTLS
++
+ [ new_oids ]
+ # We can add new OIDs in here for use by 'ca', 'req' and 'ts'.
+ # Add a simple OID like this:
+-- 
+2.25.1
+

--- a/recipes-connectivity/openssl/openssl_3.5.%.bbappend
+++ b/recipes-connectivity/openssl/openssl_3.5.%.bbappend
@@ -1,0 +1,7 @@
+FILESEXTRAPATHS:prepend:imx-nxp-bsp := "${THISDIR}/${PN}:"
+
+SRC_URI:append:imx-nxp-bsp = " \
+    file://openssl-3.0-add-Kernel-TLS-configuration.patch \
+"
+
+EXTRA_OECONF:append:imx-nxp-bsp = " enable-ktls"


### PR DESCRIPTION
Recent scarthgap revisions of oe/poky use OpenSSL 3.5 while the meta-imx scarthgap-compatible branch still provides an OpenSSL 3.2 bbappend. This causes the following parsing error:

  No recipes in default available for:
  .../openssl_3.2.%.bbappend

Mask the obsolete OpenSSL 3.2 bbappend and add a matching OpenSSL 3.5 bbappend instead.

The OpenSSL 3.5 bbappend is copied from meta-imx commit 4c236f8700fd2098827b56c33122f01e31bbe9f3.