### PR TITLE
hmm: systemd: Add custom journald.conf that limits /run use

### DIFF
--- a/recipes-core/systemd/files/verdin-am62-hmm/journald.conf
+++ b/recipes-core/systemd/files/verdin-am62-hmm/journald.conf
@@ -1,0 +1,8 @@
+# Limit volatile journald usage in /run.
+# /run is tmpfs, so excessive logs can fill up RAM-backed storage.
+
+[Journal]
+RuntimeMaxUse=20M
+RuntimeKeepFree=10M
+RuntimeMaxFileSize=4M
+RuntimeMaxFiles=4


### PR DESCRIPTION
Without limits, excessive logging can fill up the RAM-backed tmpfs mounted at /run on this platform.